### PR TITLE
Refact/aviso

### DIFF
--- a/components/AvisoForm/AvisoForm.tsx
+++ b/components/AvisoForm/AvisoForm.tsx
@@ -8,9 +8,9 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  Text,
   TouchableWithoutFeedback,
   View,
-  Text,
 } from "react-native";
 import RoundedButton from "../RoundedButton/RoundedButton";
 import InputField from "../MaterialInput/MaterialInput";
@@ -23,6 +23,8 @@ import Map from "../Map/Map";
 import { AvisoFormStyle } from "./AvisoForm.style";
 import CameraButton from "../Camera/CameraButton/CameraButton";
 import { Camera } from "expo-camera";
+import PhotoPicker from "../PhotoPicker/PhotoPicker";
+import PhotoPreview from "../Camera/PhotoPreview";
 
 /**
  * AvisoFrom es un componente que muestra almacena todos los componentes necesarios
@@ -420,18 +422,34 @@ export const AvisoForm: React.FC<
           </View>
 
           <View>
-            <Text
-              style={{ marginBottom: 10, fontSize: 16, fontWeight: "bold" }}
-            >
-              Adjunta una Foto
-            </Text>
             <Controller
               control={control}
               name="Fotografias"
               render={({ field: { onChange, value } }) => (
-                <View>
-                  <CameraButton
-                    sizeButton={50}
+                <View style={{}}>
+                  <View>
+                    <Text style={{ textAlign: "center" }}>Toma una foto</Text>
+                    <CameraButton
+                      sizeButton={50}
+                      photoUri={value}
+                      setPhotoUri={(uri: string | null) => {
+                        onChange(uri);
+                        setPhoto(uri);
+                      }}
+                    />
+                  </View>
+
+                  <PhotoPicker
+                    label="Selecciona una foto"
+                    onPhotoSelect={(uri: string | null) => {
+                      onChange(uri);
+                      setPhoto(uri);
+                    }}
+                  />
+                  <Text style={{ textAlign: "center" }}>
+                    Vista previa de la foto
+                  </Text>
+                  <PhotoPreview
                     styleCamerPreview={{
                       borderRadius: 15,
                       borderWidth: 1,
@@ -443,12 +461,8 @@ export const AvisoForm: React.FC<
                       alignItems: "center",
                       justifyContent: "center",
                     }}
-                    photoUri={value} // Pasa el valor actual del formulario
-                    setPhotoUri={(uri: string | null) => {
-                      onChange(uri); // Actualiza el valor del formulario
-                      console.log("Foto capturada:", uri);
-                    }}
-                  />
+                    photoUri={photo}
+                  ></PhotoPreview>
                 </View>
               )}
             />

--- a/components/Camera/CameraButton/CameraButton.style.ts
+++ b/components/Camera/CameraButton/CameraButton.style.ts
@@ -3,7 +3,7 @@ import { StyleSheet } from "react-native";
 export const CameraButtonStyle = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
+    alignItems: "center",
   },
   message: {
     textAlign: "center",
@@ -15,8 +15,6 @@ export const CameraButtonStyle = StyleSheet.create({
 
   button: {
     flex: 1,
-    alignSelf: "flex-end",
-    alignItems: "center",
   },
   text: {
     fontSize: 24,

--- a/components/Camera/CameraButton/CameraButton.tsx
+++ b/components/Camera/CameraButton/CameraButton.tsx
@@ -3,22 +3,21 @@ import { Alert, Linking, Pressable, View } from "react-native";
 import { CameraButtonProps } from "./types";
 import { useCameraPermissions } from "expo-camera";
 import { CameraButtonStyle } from "./CameraButton.style";
-import PhotoPreview from "../PhotoPreview";
 import CustomCameraView from "../CustomCameraView/CustomCameraView";
 import { AntDesign } from "@expo/vector-icons";
+
 /**
 
-* Componente de botón de cámara que permite tomar fotos, solicitar permisos de cámara y
-* mostrar una vista previa de la foto tomada. Maneja los permisos de cámara y proporciona opciones
-* para retomar la foto si es necesario.
-*
-* @component
-* @example
-* <CameraButton sizeButton={30} styleCamerPreview={{ borderRadius: 10 }} />
-*/
+ * Componente de botón de cámara que permite tomar fotos, solicitar permisos de cámara y
+ * mostrar una vista previa de la foto tomada. Maneja los permisos de cámara y proporciona opciones
+ * para retomar la foto si es necesario.
+ *
+ * @component
+ * @example
+ * <CameraButton sizeButton={30} styleCamerPreview={{ borderRadius: 10 }} />
+ */
 const CameraButton: React.FC<CameraButtonProps> = ({
   sizeButton = 25,
-  styleCamerPreview = {},
   photoUri,
   setPhotoUri,
 }) => {
@@ -74,37 +73,29 @@ const CameraButton: React.FC<CameraButtonProps> = ({
     );
   }
 
-  return (
-    <View style={CameraButtonStyle.container}>
-      {photoUri ? (
-        <>
-          <PhotoPreview
-            photoUri={photoUri}
-            sizeButtonPhotoPreview={sizeButton}
-            styleCamerPreview={styleCamerPreview}
-            onRetake={() => {
-              openCamera();
-              setPhotoUri(null);
-            }}
-          />
-        </>
-      ) : isCameraVisible ? (
+  if (isCameraVisible && !photoUri) {
+    return (
+      <View style={{ flex: 1 }}>
         <CustomCameraView
           CameraViewStyle={CameraButtonStyle.camera}
           onClose={closeCamera}
           setPhotoBase64={setPhotoBase64}
           setPhotoUri={setPhotoUri}
         />
-      ) : (
-        <Pressable
-          onPress={() => {
-            openCamera();
-            setPhotoUri(null);
-          }}
-        >
-          <AntDesign name="camerao" size={sizeButton} />
-        </Pressable>
-      )}
+      </View>
+    );
+  }
+
+  return (
+    <View style={CameraButtonStyle.container}>
+      <Pressable
+        onPress={() => {
+          openCamera();
+          setPhotoUri(null);
+        }}
+      >
+        <AntDesign name="camerao" size={sizeButton} />
+      </Pressable>
     </View>
   );
 };

--- a/components/Camera/CameraButton/types.d.ts
+++ b/components/Camera/CameraButton/types.d.ts
@@ -15,13 +15,6 @@ export interface CameraButtonProps {
   sizeButton?: number;
 
   /**
-   * Estilos personalizados para la vista previa de la cámara.
-   *
-   * @type {StyleProp<ImageStyle>}
-   * @default {}
-   */
-  styleCamerPreview?: StyleProp<ImageStyle>;
-  /**
    * URI de la foto capturada.
    *
    * Si no se ha capturado ninguna foto, el valor será `null`.

--- a/components/Camera/PhotoPreview.tsx
+++ b/components/Camera/PhotoPreview.tsx
@@ -10,20 +10,15 @@ import { Image } from "expo-image";
  * @component
  */
 const PhotoPreview: React.FC<{
-  photoUri: string;
-  sizeButtonPhotoPreview?: number;
+  photoUri: string | null;
   styleCamerPreview?: any;
-  onRetake: () => void;
-}> = ({ photoUri, sizeButtonPhotoPreview, styleCamerPreview, onRetake }) => (
+}> = ({ photoUri, styleCamerPreview }) => (
   <View>
     <Image
       source={{ uri: photoUri }}
       style={[CameraButtonStyle.image, styleCamerPreview]}
       contentFit={"scale-down"}
     />
-    <Pressable onPress={onRetake}>
-      <AntDesign name="camera" size={sizeButtonPhotoPreview} color="black" />
-    </Pressable>
   </View>
 );
 export default PhotoPreview;

--- a/components/CardCarousel/CardCarousel.style.ts
+++ b/components/CardCarousel/CardCarousel.style.ts
@@ -5,7 +5,6 @@ export const CardCarouselStyle = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#fff",
     padding: 40,
   },
   textHeading: {

--- a/components/CardCarousel/CardCarousel.tsx
+++ b/components/CardCarousel/CardCarousel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, Image } from "react-native";
+import { View, Text, Image, ScrollView } from "react-native";
 import { CardCarouselProps } from "./types";
 import { CardCarouselStyle } from "./CardCarousel.style";
 

--- a/components/PhotoPicker/PhotoPicker.tsx
+++ b/components/PhotoPicker/PhotoPicker.tsx
@@ -80,12 +80,6 @@ const PhotoPicker: FC<PhotoPickerProps> = ({
       >
         <Text style={PhotoPickerStyle.buttonText}>Seleccionar</Text>
       </TouchableOpacity>
-      {selectedPhoto && (
-        <Image
-          source={{ uri: selectedPhoto }}
-          style={PhotoPickerStyle.imagePreview}
-        />
-      )}
     </View>
   );
 };


### PR DESCRIPTION
## Hice un refactor al aviso
* El aviso puede seleccionar una foto ya sea tomadola desde la camara o seleccionandola desde el carrete
* Sin importar la forma la photo se mostrara en una sola vista previa
* Tuve que modificar photo picker y tambien camera button para que compartieran (dependiendo de la implementación) una sola vista previa de la foto
## Tareas pendientes
* Probar que la photo si se pase bien en el formulario
* Arreglar los estilos del formulario para que se vea mas uniforme
* OPCIONAL: Verificar que las historias (stories) no se hayan roto. En teoría, no deberían estar afectadas, pero no lo probé específicamente. En camera button y en photo picker ya no tenemos previsualización (preview).